### PR TITLE
drop support for node 6, support node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'

--- a/package.json
+++ b/package.json
@@ -35,19 +35,12 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.5",
-    "ava": "^1",
+    "ava": "*",
+    "eslint-plugin-ava": "^7.1.0",
     "get-urls": "^7.0.0",
     "pify": "^2.3.0",
     "uglifyjs-webpack-plugin": "^0.4.0",
     "webpack": "^3.1.0",
     "xo": "*"
-  },
-  "xo": {
-    "rules": [
-      [
-        "ava/no-import-test-files",
-        false
-      ]
-    ]
   }
 }


### PR DESCRIPTION
Drops support for Node 6, starts building Node 12.

`eslint-plugin-ava` needs to be manually installed since latest `xo` still only requires `eslint-plugin-ava@^5.1.0`, and our import of the `@babel`-scoped packages triggers https://github.com/avajs/eslint-plugin-ava/issues/253 (fixed in `eslint-plugin-ava@7.1`).